### PR TITLE
Fix error block width

### DIFF
--- a/static/health.css
+++ b/static/health.css
@@ -131,7 +131,7 @@ td.contributor {
 }
 
 tbody td {
-    padding: 3px 5px;
+    padding: 2px 4px;
     background-color: #f0f0f0;
     text-align: center;
 }
@@ -141,7 +141,9 @@ tbody td {
 }
 
 .bm {
-    padding: 0.1px;
+    padding: 0;
+    min-width: 8px;
+    max-width: 8px;
     white-space: pre;
 }
 


### PR DESCRIPTION
Currently, the blocks in "error" state are slightly wider than everything else, which causes the grid to display in an unpleasant way. I fixed this by changing the base `td` padding to be slightly smaller and then resetting padding to `0` on `.bm`.

Before:

<img width="1108" alt="github-before" src="https://github.com/petals-infra/health.petals.dev/assets/266545/e33263f0-389b-48ec-bfca-2901f63cfdb2">

After:

<img width="1054" alt="github-after" src="https://github.com/petals-infra/health.petals.dev/assets/266545/028119d7-4af8-439d-aae1-bcba8e26add8">

It's a small change, and it's hard to see with the way I have the data mocked up here (there wasn't an easier way of forcing the state I needed to show how bad it _can_ look) - let me know if that helps.